### PR TITLE
Feature/ecmwf data time

### DIFF
--- a/src/pyg2p/__init__.py
+++ b/src/pyg2p/__init__.py
@@ -145,7 +145,7 @@ class GribGridDetails(Loggable):
 
 class Messages(Loggable):
 
-    def __init__(self, values, mv, unit, type_of_level, type_of_step, step_units, grid_details, val_2nd=None, data_date=None):
+    def __init__(self, values, mv, unit, type_of_level, type_of_step, step_units, grid_details, val_2nd=None, data_date=None, data_time='0'):
         super().__init__()
         self.values_first_or_single_res = values
         self.values_second_res = val_2nd or {}
@@ -154,7 +154,7 @@ class Messages(Loggable):
         self.type_of_level = type_of_level
         self.unit = unit
         self.missing_value = mv
-        self.data_date = datetime.strptime(str(data_date), '%Y%m%d')
+        self.data_date = datetime.strptime(f'{data_date}{data_time}', '%Y%m%d%H')
 
         self.grid_details = grid_details
         # order key list to get first step

--- a/src/pyg2p/main/context.py
+++ b/src/pyg2p/main/context.py
@@ -268,7 +268,7 @@ class ExecutionContext(Context):
                             type=int, metavar='tend')
         parser.add_argument('-m', '--perturbationNumber', help='eps member number', type=int, metavar='eps_member')
         parser.add_argument('-T', '--dataTime', help='To select messages by dataTime key value', type=int,
-                            choices=['0', '1200'], metavar='data_time')
+                            choices=[0, 1200], metavar='data_time')
         parser.add_argument('-D', '--dataDate', help='<YYYYMMDD> to select messages by dataDate key value',
                             type=int, metavar='data_date')
 

--- a/src/pyg2p/main/readers/grib.py
+++ b/src/pyg2p/main/readers/grib.py
@@ -168,6 +168,7 @@ class GRIBReader(Loggable):
 
             missing_value = codes_get(self._selected_grbs[0], 'missingValue')
             data_date = codes_get(self._selected_grbs[0], 'dataDate')
+            data_time = codes_get(self._selected_grbs[0], 'dataTime')
             all_values = {}
             all_values_second_res = {}
             grid2 = None
@@ -207,7 +208,7 @@ class GRIBReader(Loggable):
             if grid2:
                 key_2nd_spatial_res = min(all_values_second_res.keys())
                 grid.set_2nd_resolution(grid2, key_2nd_spatial_res)
-            return Messages(all_values, missing_value, unit, type_of_level, type_of_step, step_units, grid, all_values_second_res, data_date=data_date)
+            return Messages(all_values, missing_value, unit, type_of_level, type_of_step, step_units, grid, all_values_second_res, data_date=data_date, data_time=str(data_time)[:2])
         # no messages found
         else:
             raise ApplicationException.get_exc(NO_MESSAGES, details=f'using {kwargs}')


### PR DESCRIPTION
Hi @doc78 ,

We found during testing for Creating netcdf files for EFAS (which runs on 00 and 12z cycles) that you cannot infact create netcdf's for 12z...
The dataTime variable from the grib was never read, and so due to the use of datetime library the hour defaults to 0 meaning running pyg2p with data for 2023071212 would give a netcdf 2023071200.

Also the argparse was expecting one of two values, in the --dataTime field, The choices are strings but the type was int so it was unusable.
Chris